### PR TITLE
Fix some ground truth

### DIFF
--- a/ground-truth/001.gt.txt
+++ b/ground-truth/001.gt.txt
@@ -1,1 +1,1 @@
-Andriolln Agostino, Jäg., TJR. Nr. 4, 1. Komp., Tirol,
+Andriolla Agostino, Jäg., TJR. Nr. 4, 1. Komp., Tirol,

--- a/ground-truth/004.gt.txt
+++ b/ground-truth/004.gt.txt
@@ -1,1 +1,1 @@
-Kolomea, Debeslawce, 1886, kriegsgef. (Tomsk, Ruß-
+Kolomea, Debesławce, 1886, kriegsgef. (Tomsk, Ruß-

--- a/ground-truth/019.gt.txt
+++ b/ground-truth/019.gt.txt
@@ -1,1 +1,1 @@
-Apollnnia Richard, Jäger, TJR. Nr. 4, 2. Komp., Tirol,
+Apollania Richard, Jäger, TJR. Nr. 4, 2. Komp., Tirol,

--- a/ground-truth/021.gt.txt
+++ b/ground-truth/021.gt.txt
@@ -1,1 +1,1 @@
-Arifović Abid. Inft., bh. IR. Nr. 3, 14. Komp., verw.
+Arifović Abid, Inft., bh. IR. Nr. 3, 14. Komp., verw.

--- a/ground-truth/024.gt.txt
+++ b/ground-truth/024.gt.txt
@@ -1,1 +1,1 @@
-Bóbrka, Mołodyńcze, 1886, kriegsgef. (Lipezk, Gouvernc-
+Bóbrka, Mołodyńcze, 1886, kriegsgef. (Lipezk, Gouverne-

--- a/ground-truth/037.gt.txt
+++ b/ground-truth/037.gt.txt
@@ -1,1 +1,1 @@
-Gouvernement. Akmolinsk, Rußland).
+Gouvernement Akmolinsk, Rußland).

--- a/ground-truth/038.gt.txt
+++ b/ground-truth/038.gt.txt
@@ -1,1 +1,1 @@
-Andy Franz, EinjFreiw. Tit Refr., IR. Nr. 53, 15. Komp.,
+Andy Franz, EinjFreiw. TitGefr., IR. Nr. 53, 15. Komp.,

--- a/ground-truth/040.gt.txt
+++ b/ground-truth/040.gt.txt
@@ -1,1 +1,1 @@
-Auer Anton, Jger, TJR. Nr. 4, 2. Komp., Tirol, Bruneck
+Auer Anton, Jäger, TJR. Nr. 4, 2. Komp., Tirol, Bruneck

--- a/ground-truth/042.gt.txt
+++ b/ground-truth/042.gt.txt
@@ -1,1 +1,1 @@
-Augschöll, Vinzenz, Jäger, TJR. Nr. 4, 2. Komp., Tirol,
+Augschöll Vinzenz, Jäger, TJR. Nr. 4, 2. Komp., Tirol,

--- a/ground-truth/054.gt.txt
+++ b/ground-truth/054.gt.txt
@@ -1,1 +1,1 @@
-Babiak Peter, Getr., IR. Nr. 10, 3. Baon, kriegsgef.
+Babiak Peter, Gefr., IR. Nr. 10, 3. Baon, kriegsgef.

--- a/ground-truth/064.gt.txt
+++ b/ground-truth/064.gt.txt
@@ -1,1 +1,1 @@
-Babić Pavao, Inft., IR. Nr. 53, 10. Komp., Kroatien, Dvor,
+Babić Pavao, Inft., IR. Nr. 53, 16. Komp., Kroatien, Dvor,

--- a/ground-truth/067.gt.txt
+++ b/ground-truth/067.gt.txt
@@ -1,1 +1,1 @@
-. Capodistria Muggia, 1893, tot (26./2. 1915).
+Capodistria Muggia, 1893, tot (26./2. 1915).

--- a/ground-truth/072.gt.txt
+++ b/ground-truth/072.gt.txt
@@ -1,1 +1,1 @@
-Mähren, Märhrisch-Kromau, Aujezd, 1876, kriegsgef.
+Mähren, Mährisch-Kromau, Aujezd, 1876, kriegsgef.

--- a/ground-truth/074.gt.txt
+++ b/ground-truth/074.gt.txt
@@ -1,1 +1,1 @@
-Bac Basil. Inft., IR. Nr. 10, 4. Baon, kriegsgef.
+Bac Basil, Inft., IR. Nr. 10, 4. Baon, kriegsgef.

--- a/ground-truth/077.gt.txt
+++ b/ground-truth/077.gt.txt
@@ -1,1 +1,1 @@
-Baček Josip. ResZugsf., IR. Nr. 59, 16. Komp., Kroatien,
+Baček Josip. ResZugsf., IR Nr. 59, 16. Komp., Kroatien,

--- a/ground-truth/079.gt.txt
+++ b/ground-truth/079.gt.txt
@@ -1,1 +1,1 @@
-Bach Osias, Inft., IR. Nr. 10. 4. Baon., kriegsgef.
+Bach Osias, Inft., IR. Nr. 10, 4. Baon., kriegsgef.

--- a/ground-truth/080.gt.txt
+++ b/ground-truth/080.gt.txt
@@ -1,1 +1,1 @@
-Bachl Anton, ErsRes., k. k. LIR. Nr. 26, 9. Komp., tot.
+Bachl Anton, ErsRes., k. k. LIR. Nr. 26, 9. Komp., tot

--- a/ground-truth/082.gt.txt
+++ b/ground-truth/082.gt.txt
@@ -1,1 +1,1 @@
-Bachmann Anton. Jäger, TJR. Nr. 4, 2. Komp., Tirol,
+Bachmann Anton, Jäger, TJR. Nr. 4, 2. Komp., Tirol,

--- a/ground-truth/083.gt.txt
+++ b/ground-truth/083.gt.txt
@@ -1,1 +1,1 @@
-Bruneck, Niederorf. 1894, verw.
+Bruneck, Niederdorf. 1894, verw.

--- a/ground-truth/085.gt.txt
+++ b/ground-truth/085.gt.txt
@@ -1,1 +1,1 @@
-Tachau, Neudorf, 18994, verwundet.
+Tachau, Neudorf, 1894, verwundet.

--- a/ground-truth/086.gt.txt
+++ b/ground-truth/086.gt.txt
@@ -1,1 +1,1 @@
-Bachmann Matthias, Jäger. TJR. Nr. 4, 2. Komp., Tirol,
+Bachmann Matthias, Jäger, TJR. Nr. 4, 2. Komp., Tirol,

--- a/ground-truth/089.gt.txt
+++ b/ground-truth/089.gt.txt
@@ -1,1 +1,1 @@
-Bačić Nazif, Inft., bh. IR. Nr. 3. 1. Komp., verw.
+Bačić Nazif, Inft., bh. IR. Nr. 3, 1. Komp., verw.

--- a/ground-truth/092.gt.txt
+++ b/ground-truth/092.gt.txt
@@ -1,1 +1,1 @@
-Badenić Blaž, Inft., IR. Nr. 53, 10. Komp., Kroatien, Bel.
+Badenić Blaž, Inft., IR. Nr. 53, 16. Komp., Kroatien, Bel.

--- a/ground-truth/103.gt.txt
+++ b/ground-truth/103.gt.txt
@@ -1,1 +1,1 @@
-Bajdnk Imbro, Inft., IR. Nr. 53, 13. Komp., Kroatien,
+Bajdak Imbro, Inft., IR. Nr. 53, 13. Komp., Kroatien,

--- a/ground-truth/108.gt.txt
+++ b/ground-truth/108.gt.txt
@@ -1,1 +1,1 @@
-Bakar Johaun. Inft., IR. Nr. 10, 4. Baon, kriegsgef.
+Bakar Johann. Inft., IR. Nr. 10, 4. Baon, kriegsgef.

--- a/ground-truth/111.gt.txt
+++ b/ground-truth/111.gt.txt
@@ -1,1 +1,1 @@
-Baldas Peter Inft., IR. Nr. 7, 10. Komp., verw.
+Baldas Peter, Inft., IR. Nr. 7, 16. Komp., verw.

--- a/ground-truth/113.gt.txt
+++ b/ground-truth/113.gt.txt
@@ -1,1 +1,1 @@
-verw,,
+verw.

--- a/ground-truth/117.gt.txt
+++ b/ground-truth/117.gt.txt
@@ -1,1 +1,1 @@
-Balin Josef, Inft., IR Nr. 88, 9. Komp., Böhmen, Kralowitz,
+Balin Josef, Inft., IR. Nr. 88, 9. Komp., Böhmen, Kralowitz,

--- a/ground-truth/132.gt.txt
+++ b/ground-truth/132.gt.txt
@@ -1,1 +1,1 @@
-Banovec Ivan, Inft., IR. Nr. 53, 15. Komp., Kroatien,
+Banovec Ivan, Inft., IR. Nr. 53, 13. Komp., Kroatien,

--- a/ground-truth/143.gt.txt
+++ b/ground-truth/143.gt.txt
@@ -1,1 +1,1 @@
-Barazutti. Anton, Offiziersdiener, IR. Nr. 27, 5. Komp.,
+Barazutti Anton, Offiziersdiener, IR. Nr. 27, 5. Komp.,

--- a/ground-truth/144.gt.txt
+++ b/ground-truth/144.gt.txt
@@ -1,1 +1,1 @@
-kriegsgef..
+kriegsgef.

--- a/ground-truth/147.gt.txt
+++ b/ground-truth/147.gt.txt
@@ -1,1 +1,1 @@
-Barholini Giuseppe, Jäg., TJR.. Nr. 4, 4. Komp., Tirol,
+Barbolini Giuseppe, Jäg., TJR. Nr. 4, 4. Komp., Tirol,

--- a/ground-truth/148.gt.txt
+++ b/ground-truth/148.gt.txt
@@ -1,1 +1,1 @@
-Oavalese, 1893, verw.
+Cavalese, 1893, verw.

--- a/ground-truth/149.gt.txt
+++ b/ground-truth/149.gt.txt
@@ -1,1 +1,1 @@
-Bareik Michael. Inft., IR. Nr. 10, 4. Baon., kriegsgef.
+Barcik Michael, Inft., IR. Nr. 10, 4. Baon., kriegsgef.


### PR DESCRIPTION
I checked the differences between the ground truth and the recognized text:

![git-diff-gt-ocr](https://cloud.githubusercontent.com/assets/5199995/22618300/3a0b2a66-ead9-11e6-8235-9ead50480dd6.png)

Thereby I found some inconsistencies in the ground truth, which this PR will correct. I checked all of these things manually against the images. I didn't include some cases with differences of `.` vs. `,` because I couldn't decide what is "correct". The things here should be conform with the pictures (if I hadn't made any errors).